### PR TITLE
update recipe to work with new version on defaults

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,16 +33,20 @@ test:
     - openapi_schema_validator
   commands:
     - pip check
-    - pytest ./tests --capture=no --verbose --showlocals
+    - pytest ./tests --capture=no --verbose --showlocals --junitxml=reports/junit.xml --cov=openapi_schema_validator --cov-report=term-missing --cov-report=xml
   requires:
     - pip
     - pytest
+    - pytest-cov 
 
 about:
   home: https://github.com/p1c2u/openapi-schema-validator
   summary: OpenAPI schema validation for Python
+  doc_source_url: https://github.com/p1c2u/openapi-schema-validator
+  dev_url: https://github.com/p1c2u/openapi-schema-validator
   license: BSD-3-Clause
   license_file: LICENSE
+  license-family: BSD
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,24 +20,21 @@ requirements:
     - python
   run:
     - python
-    - attrs >=19.2.0
-    - jsonschema >=4.19.1
-    - jsonschema-specifications >=2023.5.2
+    - jsonschema >=4.19.1,<5.0.0a0
+    - jsonschema-specifications >=2023.5.2,<2024.0.0
     - rfc3339-validator
 
 test:
   source_files:
-    - openapi_schema_validator/
-    - tests/
+    - tests
   imports:
     - openapi_schema_validator
   commands:
     - pip check
-    - pytest ./tests --capture=no --verbose --showlocals --junitxml=reports/junit.xml --cov=openapi_schema_validator --cov-report=term-missing --cov-report=xml
+    - pytest -vv --cov=openapi_schema_validator --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=80
   requires:
     - pip
-    - pytest
-    - pytest-cov 
+    - pytest-cov
 
 about:
   home: https://github.com/p1c2u/openapi-schema-validator

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.3" %}
+{% set version = "0.6.2" %}
 
 package:
   name: openapi-schema-validator
@@ -6,22 +6,22 @@ package:
 
 source:
   url: https://pypi.io/packages/source/o/openapi-schema-validator/openapi_schema_validator-{{ version }}.tar.gz
-  sha256: 6940dba9f4906c97078fea6fd9d5a3a3384207db368c4e32f6af6abd7c5c560b
+  sha256: 11a95c9c9017912964e3e5f2545a5b11c3814880681fcacfb73b1759bb4f2804
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
     - poetry-core >=1.0.0
-    - python >=3.7
+    - python
   run:
+    - python
     - attrs >=19.2.0
-    - jsonschema >=4.0.0,<5.0.0
-    - python >=3.7
+    - jsonschema 
+    - jsonschema-specifications
     - rfc3339-validator
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: 11a95c9c9017912964e3e5f2545a5b11c3814880681fcacfb73b1759bb4f2804
 
 build:
+  skip: true # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -20,17 +21,22 @@ requirements:
   run:
     - python
     - attrs >=19.2.0
-    - jsonschema 
-    - jsonschema-specifications
+    - jsonschema >=4.19.1
+    - jsonschema-specifications >=2023.5.2
     - rfc3339-validator
 
 test:
+  source_files:
+    - openapi_schema_validator/
+    - tests/
   imports:
     - openapi_schema_validator
   commands:
     - pip check
+    - pytest ./tests --capture=no --verbose --showlocals
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/p1c2u/openapi-schema-validator

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
     - openapi_schema_validator
   commands:
     - pip check
+    # skipping test_array_prefixitems_invalid because of https://github.com/python-openapi/openapi-schema-validator/issues/153
     - pytest -vv --cov=openapi_schema_validator --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=80 -k "not test_array_prefixitems_invalid[value0]"
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ test:
     - openapi_schema_validator
   commands:
     - pip check
-    - pytest -vv --cov=openapi_schema_validator --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=80
+    - pytest -vv --cov=openapi_schema_validator --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=80 -k "not test_array_prefixitems_invalid[value0]"
   requires:
     - pip
     - pytest-cov

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ about:
   summary: OpenAPI schema validation for Python
   description: |
     OpenAPI schema validation for Python
-  doc_source_url: https://github.com/p1c2u/openapi-schema-validator
+  doc_url: https://openapi-schema-validator.readthedocs.io
   dev_url: https://github.com/p1c2u/openapi-schema-validator
   license: BSD-3-Clause
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,11 +42,13 @@ test:
 about:
   home: https://github.com/p1c2u/openapi-schema-validator
   summary: OpenAPI schema validation for Python
+  description: |
+    OpenAPI schema validation for Python
   doc_source_url: https://github.com/p1c2u/openapi-schema-validator
   dev_url: https://github.com/p1c2u/openapi-schema-validator
   license: BSD-3-Clause
   license_file: LICENSE
-  license-family: BSD
+  license_family: BSD
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,10 +32,10 @@ test:
   commands:
     - pip check
     # skipping test_array_prefixitems_invalid because of https://github.com/python-openapi/openapi-schema-validator/issues/153
-    - pytest -vv --cov=openapi_schema_validator --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=80 -k "not test_array_prefixitems_invalid[value0]"
+    - pytest -v -k "not test_array_prefixitems_invalid[value0]"
   requires:
     - pip
-    - pytest-cov
+    - pytest
 
 about:
   home: https://github.com/p1c2u/openapi-schema-validator


### PR DESCRIPTION
openapi-schema-validator 0.6.2

**Destination channel:** defaults

### Links

- [PKG-4428](https://anaconda.atlassian.net/browse/PKG-4428) 
- [Upstream repository](https://github.com/p1c2u/openapi-schema-validator)
- [Upstream changelog/diff](https://github.com/python-openapi/openapi-schema-validator/releases/tag/0.6.2)
- Relevant dependency PRs:
  - moto

### Explanation of changes:
- get ready for defaults upload


[PKG-4428]: https://anaconda.atlassian.net/browse/PKG-4428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ